### PR TITLE
Add newline delimiter when splitting a word

### DIFF
--- a/dist/utils/wordObjectsBuilder.js
+++ b/dist/utils/wordObjectsBuilder.js
@@ -19,7 +19,7 @@ var wordObjectsBuilder = function wordObjectsBuilder(_ref) {
       region = _formatLanguage.region;
 
   var activeSentenceBoundary = true;
-  var words = string.split(' ');
+  var words = string.split(/(?=[\n])| /);
   return words.map(function (word, index) {
     // Maintain raw casing if proper noun, otherwise lowercase it
     var value = (0, _helpers.casedValue)({

--- a/src/utils/wordObjectsBuilder.js
+++ b/src/utils/wordObjectsBuilder.js
@@ -11,7 +11,7 @@ const wordObjectsBuilder = ({ string, unformattedLanguage, trueCasing, properNou
 
   const { language, region } = formatLanguage(unformattedLanguage);
   var activeSentenceBoundary = true;
-  const words = string.split(' ');
+  const words = string.split(/(?=[\n])| /);
 
   return words.map((word, index) => {
     // Maintain raw casing if proper noun, otherwise lowercase it

--- a/tests/testCases.js
+++ b/tests/testCases.js
@@ -8,6 +8,10 @@ export default [
           output: "And I Love You!",
         },
         {
+          input: "and\ni love you!",
+          output: "And \nI Love You!",
+        },
+        {
           input: "the challenge of",
           output: "The Challenge Of",
         },
@@ -66,9 +70,9 @@ export default [
         },
         {
           input:
-            'he walked in. "hi," he said! she replied, "yes?" "oh, nevermind."',
+            'he walked in. "hi," he said!\nshe replied, "yes?" "oh, nevermind."',
           output:
-            'He walked in. "Hi," he said! She replied, "Yes?" "Oh, nevermind."',
+            'He walked in. "Hi," he said! \nShe replied, "Yes?" "Oh, nevermind."',
         },
         {
           input: "the 12 oz. drink was cold",

--- a/tests/testCases.js
+++ b/tests/testCases.js
@@ -36,6 +36,10 @@ export default [
           output: "This is a Test",
         },
         {
+          input: "this\nis\na\ntest",
+          output: "This \nIs \nA \nTest",
+        },
+        {
           input: "",
           output: "",
         },
@@ -70,9 +74,9 @@ export default [
         },
         {
           input:
-            'he walked in. "hi," he said!\nshe replied, "yes?" "oh, nevermind."',
+            'he walked in. "hi," he said! she replied, "yes?" "oh, nevermind."',
           output:
-            'He walked in. "Hi," he said! \nShe replied, "Yes?" "Oh, nevermind."',
+            'He walked in. "Hi," he said! She replied, "Yes?" "Oh, nevermind."',
         },
         {
           input: "the 12 oz. drink was cold",
@@ -81,6 +85,10 @@ export default [
         {
           input: "We can't stop",
           output: "We can't stop",
+        },
+        {
+          input: "We.\ncan't.\nstop",
+          output: "We. \nCan't. \nStop",
         },
         {
           input: "",


### PR DESCRIPTION
Fixes [ENG-1411](https://linear.app/woflow/issue/ENG-1411/line-breaks-cause-casing-issues)

The issue:
The character after the newline character will not be Titleized because it is not recognized as a separate word (it was part of the previous word + '\n', e.g. `We.\ncan't.\nstop` instead of separate words:`We.\n`, `can't.\n`, `stop`).  The result is that `can't` and `stop` are still lowercased (green color = expected, red color = actual):
<img width="133" alt="Screen Shot 2023-03-13 at 12 42 42 PM" src="https://user-images.githubusercontent.com/4252002/224815197-a040adc4-5047-46f0-b20c-508bd04375a9.png">

Use positive lookahead to break the newlines into separate words for processing, as well as preserving the newline character

TODO:
- publish new version and update BE tests
- update version in package.json on all the apps